### PR TITLE
🛠️ Commit: Enhanced AD group comparison – separate user group mapping…

### DIFF
--- a/adgroupcomparator/GroupComparator.ps1
+++ b/adgroupcomparator/GroupComparator.ps1
@@ -7,8 +7,7 @@ $groups = @{}
 # Retrieve all Active Directory groups with their DN, Name, and GroupCategory properties
 # Filter only for "Security" groups
 $groupArray = Get-ADGroup -Filter * -Properties DistinguishedName, Name, GroupCategory |
-    Select-Object -Property DistinguishedName, Name, GroupCategory |
-    Where-Object { $_.GroupCategory -eq "Security" }
+    Select-Object -Property DistinguishedName, Name, GroupCategory 
 
 # Populate the hashtable: DN as key, group name as value
 foreach ($group in $groupArray) {
@@ -22,16 +21,16 @@ $users = New-Object System.Collections.ArrayList
 $neededUsers = Read-Host("How many users would you like to compare?")
 
 # Loop to collect each user based on user input
-for ($i = 1; $i -le $neededUsers; $i++) {
+for ($i = 0; $i -lt $neededUsers; $i++) {
     &{
         # Ask for the username input
-        $user = Read-Host("Enter user number $($i)")
+        $user = Read-Host("Enter user number $($i+1)")
 
         try {
             # Try to get the AD user with their name and group memberships (MemberOf)
             $users.Add(
-                Get-ADUser -Identity $user -Properties Name, MemberOf |
-                Select-Object -Property Name, MemberOf
+                (Get-ADUser -Identity $user -Properties Name, SamAccountName, MemberOf |
+                Select-Object -Property Name, SamAccountName, MemberOf)
             )
         }
         catch {
@@ -45,10 +44,36 @@ for ($i = 1; $i -le $neededUsers; $i++) {
 foreach ($user in $users) {
     Write-Host ("User: $($user.Name)")
     Write-Host ("Number of groups: {0}" -f $user.MemberOf.Count)
-    Write-Host "Groups:"
+    Write-Host ("Groups:")
 
     # Loop through each group DN and write the corresponding group name
     foreach ($dn in $user.MemberOf) {
-        Write-Host ("- {0}" -f $groups[$dn])
+        Write-Host ("- {0}" -f $groups[$dn])   
+    }
+    Write-Host("")
+}
+
+$userGroupArray = @()
+
+for($i=0; $i -lt $neededUsers; $i++){
+    if(($users[$i].MemberOf -eq $null) -or ($users[$i].MemberOf.Count -eq 0)){
+        $userGroupArray += "no groups"
+    }else{
+        $userGroupArray += $users[$i].MemberOF
+    } 
+}
+
+$userGroupArray | Get-Member
+
+for($i=0; $i -lt $neededUsers; $i++){
+    foreach ($dn in $userGroupArray.MemberOf) {
+        Write-Host ("- {0}" -f $groups[$dn])        
     }
 }
+
+
+
+
+#Get-ADUser -Identity a.szyniec -Properties *
+
+#for($j=0;$j -lt $user[$i].MemberOf.Count){}


### PR DESCRIPTION
…, added SamAccountName, handled empty memberships

🛠️ feat: added userGroupArray to manage and output AD group memberships per user
🔢 fix: use zero-based index for loop consistency
🧾 feat: added SamAccountName to user properties
🚫 fix: handle users with no groups
🧪 chore: inspect group array structure with Get-Member
🔁 refactor: additional group output loop using new array